### PR TITLE
Add @stitchapi/sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Sentry instruments your application with observability, such as error tracking a
 #### Tools
 
 - [webvitals.com][webvitals-url] - Interactive tool that demonstrates and explains each Web Vital.
+- [@stitchapi/sentry](https://github.com/rejifald/StitchAPI/tree/main/packages/sentry) - A Sentry TraceSink for StitchAPI that records API calls as breadcrumbs and captures failures as issues (metadata only).
 
 ## Sentry using Sentry
 


### PR DESCRIPTION
Adds `@stitchapi/sentry` under **Full-Stack Development → Debugging / Monitoring Applications → Tools**.

[`@stitchapi/sentry`](https://github.com/rejifald/StitchAPI/tree/main/packages/sentry) is a Sentry `TraceSink` for [StitchAPI](https://stitchapi.dev): routine outbound API calls become `stitch` breadcrumbs and a failed call is captured as an issue, so the breadcrumb trail attaches automatically. Bring-your-own SDK (`@sentry/node` / `browser` / `react`); sends metadata only (never headers or bodies).

- Searched for duplicates — none.
- Standard `- [name](url) - desc.` format; added to the bottom of Tools.